### PR TITLE
Move menu item to after 'Build Tools'

### DIFF
--- a/Pasfmt.Main.pas
+++ b/Pasfmt.Main.pas
@@ -93,7 +93,7 @@ begin
   MenuItem.Action := CreateAction('PasfmtOpenSettings', '&Settings...', OnSettingsActionExecute);
   FPasfmtMenu.Add(MenuItem);
 
-  (BorlandIDEServices as INTAServices).AddActionMenu('ViewTranslationManagerMenu', nil, FPasfmtMenu);
+  (BorlandIDEServices as INTAServices).AddActionMenu('CustomToolsItem', nil, FPasfmtMenu);
   FKeyboardBindingIndex :=
       (BorlandIDEServices as IOTAKeyboardServices).AddKeyboardBinding(TPasfmtKeyboardBinding.Create);
   FAddInOptions := TPasfmtAddInOptions.Create;


### PR DESCRIPTION
The 'Translation Manager' menu item isn't there for me in Delphi 12,
making the plugin fail to load.
