### PR TITLE
Switch to faster update mode when file is above configured threshold

### DIFF
--- a/Pasfmt.Main.pas
+++ b/Pasfmt.Main.pas
@@ -134,6 +134,7 @@ var
 begin
   Formatter.Core.Executable := PasfmtSettings.ExecutablePath;
   Formatter.Core.Timeout := PasfmtSettings.FormatTimeout;
+  Formatter.MaxFileKiBWithUndoHistory := PasfmtSettings.MaxFileKiBWithUndoHistory;
 
   Project := (BorlandIDEServices as IOTAModuleServices).GetActiveProject;
   if Assigned(Project) then begin

--- a/Pasfmt.Settings.pas
+++ b/Pasfmt.Settings.pas
@@ -12,6 +12,7 @@ type
       CExecutablePathName = 'Executable Path';
       CFormatOnSaveName = 'Format On Save';
       CFormatTimeoutName = 'Format Timeout';
+      CMaxFileKiBWithUndoHistory = 'Max File Size With Undo History';
   private
     FRegistry: TRegistry;
     FBaseKey: string;
@@ -20,11 +21,13 @@ type
     FExecutablePath: string;
     FFormatOnSave: Boolean;
     FFormatTimeout: Integer;
+    FMaxFileKiBWithUndoHistory: Integer;
 
     procedure SetLogLevel(Value: TLogLevel);
     procedure SetExecutablePath(Value: string);
     procedure SetFormatOnSave(Value: Boolean);
     procedure SetFormatTimeout(Value: Integer);
+    procedure SetMaxFileKiBWithUndoHistory(Value: Integer);
   public
     constructor Create;
     destructor Destroy; override;
@@ -35,6 +38,7 @@ type
     property ExecutablePath: string read FExecutablePath write SetExecutablePath;
     property FormatOnSave: Boolean read FFormatOnSave write SetFormatOnSave;
     property FormatTimeout: Integer read FFormatTimeout write SetFormatTimeout;
+    property MaxFileKiBWithUndoHistory: Integer read FMaxFileKiBWithUndoHistory write SetMaxFileKiBWithUndoHistory;
   end;
 
 function PasfmtSettings: TPasfmtSettings;
@@ -117,6 +121,20 @@ end;
 
 //______________________________________________________________________________________________________________________
 
+procedure TPasfmtSettings.SetMaxFileKiBWithUndoHistory(Value: Integer);
+begin
+  FMaxFileKiBWithUndoHistory := Value;
+
+  FRegistry.OpenKey(FBaseKey, True);
+  try
+    FRegistry.WriteInteger(CMaxFileKiBWithUndoHistory, Value);
+  finally
+    FRegistry.CloseKey;
+  end;
+end;
+
+//______________________________________________________________________________________________________________________
+
 procedure TPasfmtSettings.SetLogLevel(Value: TLogLevel);
 begin
   FLogLevel := Value;
@@ -139,6 +157,7 @@ begin
     FExecutablePath := '';
     FFormatOnSave := False;
     FFormatTimeout := 500;
+    FMaxFileKiBWithUndoHistory := 1024;
 
     if FRegistry.ValueExists(CLogLevelName) then
       FLogLevel := TLogLevel(FRegistry.ReadInteger(CLogLevelName))
@@ -159,6 +178,11 @@ begin
       FFormatTimeout := FRegistry.ReadInteger(CFormatTimeoutName)
     else
       FRegistry.WriteInteger(CFormatTimeoutName, FFormatTimeout);
+
+    if FRegistry.ValueExists(CMaxFileKiBWithUndoHistory) then
+      FMaxFileKiBWithUndoHistory := FRegistry.ReadInteger(CMaxFileKiBWithUndoHistory)
+    else
+      FRegistry.WriteInteger(CMaxFileKiBWithUndoHistory, FMaxFileKiBWithUndoHistory);
   finally
     FRegistry.CloseKey;
   end;

--- a/Pasfmt.SettingsFrame.dfm
+++ b/Pasfmt.SettingsFrame.dfm
@@ -1,21 +1,21 @@
-﻿object PasfmtSettingsFrame: TPasfmtSettingsFrame
+object PasfmtSettingsFrame: TPasfmtSettingsFrame
   Left = 0
   Top = 0
-  Width = 390
-  Height = 334
+  Width = 392
+  Height = 376
   Constraints.MinHeight = 180
   Constraints.MinWidth = 390
   TabOrder = 0
   object LogLevelLabel: TLabel
     Left = 3
     Top = 48
-    Width = 126
+    Width = 116
     Height = 15
     Caption = 'Minimum log severity'
   end
   object ExePathLabel: TLabel
     Left = 3
-    Top = 159
+    Top = 205
     Width = 103
     Height = 15
     Caption = 'Executable location'
@@ -34,6 +34,18 @@
     Height = 15
     Caption = 'Format timeout (ms)'
   end
+  object FastModeThresholdLabel: TLabel
+    Left = 3
+    Top = 155
+    Width = 220
+    Height = 15
+    Cursor = crHelp
+    Hint = 
+      'To avoid performance issues with updating large files, a faster method ' +
+      'is used when the file size exceeds this configured threshold.'#13#10'This ' +
+      'faster method unfortunately clears the undo history of the edit buffer.'
+    Caption = 'Maximum file size with undo history (KiB)'
+  end
   object LogLevelCombo: TComboBox
     Left = 11
     Top = 66
@@ -50,7 +62,7 @@
   end
   object ExePathBrowseButton: TButton
     Left = 309
-    Top = 246
+    Top = 304
     Width = 71
     Height = 23
     Caption = 'Browse...'
@@ -59,7 +71,7 @@
   end
   object ExePathRadioGroup: TRadioGroup
     Left = 3
-    Top = 159
+    Top = 210
     Width = 185
     Height = 65
     ItemIndex = 0
@@ -72,7 +84,7 @@
   end
   object ExePathEdit: TEdit
     Left = 29
-    Top = 223
+    Top = 275
     Width = 351
     Height = 23
     TabOrder = 1
@@ -95,6 +107,17 @@
     ShowHint = True
     TabOrder = 5
     Text = '500'
+  end
+  object FastModeThresholdEdit: TEdit
+    Left = 11
+    Top = 173
+    Width = 129
+    Height = 23
+    NumbersOnly = True
+    ParentShowHint = False
+    ShowHint = True
+    TabOrder = 6
+    Text = '1024'
   end
   object ExeChooseDialog: TOpenDialog
     Filter = 'Executable files (*.exe)|*.exe'

--- a/Pasfmt.SettingsFrame.pas
+++ b/Pasfmt.SettingsFrame.pas
@@ -17,6 +17,8 @@ type
     UserSettingsLabel: TLabel;
     TimeoutLabel: TLabel;
     TimeoutEdit: TEdit;
+    FastModeThresholdEdit: TEdit;
+    FastModeThresholdLabel: TLabel;
     procedure ExePathBrowseButtonClick(Sender: TObject);
     procedure ExePathRadioGroupClick(Sender: TObject);
   public
@@ -55,6 +57,7 @@ begin
   FFrame.UpdateExePathControls(PasfmtSettings.ExecutablePath);
   FFrame.OnSaveCheckBox.Checked := PasfmtSettings.FormatOnSave;
   FFrame.TimeoutEdit.Text := IntToStr(PasfmtSettings.FormatTimeout);
+  FFrame.FastModeThresholdEdit.Text := IntToStr(PasfmtSettings.MaxFileKiBWithUndoHistory);
 end;
 
 //______________________________________________________________________________________________________________________
@@ -63,6 +66,7 @@ procedure TPasfmtAddInOptions.DialogClosed(Accepted: Boolean);
 var
   LogLevelOrd: Integer;
   NewTimeout: Integer;
+  NewThreshold: Integer;
 begin
   if Accepted then begin
     PasfmtSettings.ExecutablePath := IfThen(FFrame.ExePathRadioGroup.ItemIndex = 1, Trim(FFrame.ExePathEdit.Text), '');
@@ -82,6 +86,10 @@ begin
 
     if not PasfmtSettings.FormatOnSave then begin
       OnSaveInstaller.UninstallAll;
+    end;
+
+    if TryStrToInt(FFrame.FastModeThresholdEdit.Text, NewThreshold) then begin
+      PasfmtSettings.MaxFileKiBWithUndoHistory := NewThreshold;
     end;
   end;
 


### PR DESCRIPTION
Unfortunately, using the 'undoable writer' to update the edit buffer via
the ToolsAPI is very slow, tending towards unusable on large files.

In my testing I found that the lag becomes noticable for files above
1MiB, and the editor becomes completely unresponsive for files around
10MiB.

There is a faster method for updating the buffer, but it destroys the
undo history. On balance, losing the undo history seems like a fair
compromise for keeping the editor responsive. However, it's not possible
for us to say at what file size these performance issues become a
problem on other machines and other files, so I've created a setting to
control the file size threshold.
