### PR TITLE
Fix access violation in logging on shutdown

### DIFF
--- a/Pasfmt.Log.pas
+++ b/Pasfmt.Log.pas
@@ -20,6 +20,7 @@ type
   end;
 
 function Log: ILogger;
+procedure FinalizeLog;
 
 implementation
 
@@ -58,6 +59,7 @@ type
 
 var
   GLog: ILogger;
+  GFinalized: Boolean;
 
 function Log: ILogger;
 begin
@@ -67,6 +69,14 @@ begin
   end;
 
   Result := GLog;
+end;
+
+//______________________________________________________________________________________________________________________
+
+
+procedure FinalizeLog;
+begin
+  GFinalized := True;
 end;
 
 //______________________________________________________________________________________________________________________
@@ -175,6 +185,13 @@ procedure TMessageWindowLogger.Log(Msg: string; Prefix: string);
 var
   Dummy: Pointer;
 begin
+  if GFinalized then begin
+    // When the IDE starts to close, the IDE's services become increasingly unreliable.
+    // In particular, the message box services start throwing AVs after a certain point in the closing process,
+    // so we can no longer use them to log messages. In this circumstance we just swallow the messages for now.
+    Exit;
+  end;
+
   EnsureGroup;
   (BorlandIDEServices as IOTAMessageServices).AddToolMessage('', Msg, Prefix, 0, 0, nil, Dummy, FGroup);
 end;

--- a/Pasfmt.Main.pas
+++ b/Pasfmt.Main.pas
@@ -138,6 +138,7 @@ end;
 
 destructor TPlugin.Destroy;
 begin
+  FinalizeLog;
   (BorlandIDEServices as IOTAEditorServices).RemoveNotifier(FEditorIndex);
   (BorlandIDEServices as IOTAAboutBoxServices).RemovePluginInfo(FInfoIndex);
   (BorlandIDEServices as INTAEnvironmentOptionsServices).UnregisterAddInOptions(FAddInOptions);


### PR DESCRIPTION
Fixes an access violation that can happen when a message is logged during shutdown of the IDE. Although it's not an ideal fix, this PR resolves the issue by preventing any further log messages after `GPlugin` is destroyed.