### PR TITLE
Confirm with user when formatting in a debug session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Support for updating breakpoints and bookmarks after the buffer rewrite.
+* Confirmation prompt for formatting while debugging.
 
 ## [0.1.0] - 2025-02-20
 

--- a/Pasfmt.Main.pas
+++ b/Pasfmt.Main.pas
@@ -207,6 +207,7 @@ procedure TPlugin.OnFormatKeyPress(
     var BindingResult: TKeyBindingResult
 );
 begin
+  BindingResult := krHandled;
   Format;
 end;
 


### PR DESCRIPTION
Formatting a file while debugging causes the highlighting of the source code from the debugger to disappear and there's no way (that I've found) to get it back.

With this change, we confirm with the user via a dialog whether they really want to format while debugging.