### PR TITLE
Fix stderr reporting when special cursor line isn't found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Ignore formatting requests for files without matching file extensions (pas, dpr, dpk, inc).
+* Fix error logging when cursor metadata is not parsed correctly.
 
 ### Changed
 

--- a/Pasfmt.FormatCore.pas
+++ b/Pasfmt.FormatCore.pas
@@ -39,6 +39,7 @@ var
   StartPos: Integer;
   EndPos: Integer;
 begin
+  Result := Data;
   TagPos := System.Pos(CTag, Data);
   if TagPos > 0 then begin
     StartPos := TagPos + Length(CTag);


### PR DESCRIPTION
An easy way to reproduce this issue is to run the plugin with an old
version of pasfmt from before the `--cursor` option was added. In this
case it will tell you an error occurred but won't be able to tell you
anything about it.
