### PR TITLE
Skip formatting for unsupported file types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Ignore formatting requests for files without matching file extensions (pas, dpr, dpk, inc).
+
 ## [0.2.0] - 2025-03-18
 
 ### Added

--- a/Pasfmt.FormatEditor.pas
+++ b/Pasfmt.FormatEditor.pas
@@ -27,7 +27,8 @@ uses
   Pasfmt.Log,
   System.StrUtils,
   Vcl.Dialogs,
-  System.UITypes;
+  System.UITypes,
+  System.IOUtils;
 
 //______________________________________________________________________________________________________________________
 
@@ -89,8 +90,14 @@ var
   SourceEditor: IOTAEditorContent;
   DebuggerServices: IOTADebuggerServices;
   Cursors: TCursors;
+  Extension: string;
 begin
-  if not Supports(Buffer, IOTAEditorContent, SourceEditor) then begin
+  Extension := TPath.GetExtension(Buffer.FileName);
+  if not MatchText(Extension, ['.pas', '.dpr', '.dpk', '.inc']) then begin
+    Log.Debug('Format request ignored: unsupported file extension "%s"', [Extension]);
+    Exit;
+  end
+  else if not Supports(Buffer, IOTAEditorContent, SourceEditor) then begin
     Log.Debug('Format request ignored: the editor is not formattable', [Buffer.FileName]);
     Exit;
   end


### PR DESCRIPTION
Fixes #22.

I wish there was a better way to check a file 'type' rather than checking the extension, but I don't think the ToolsAPI provides it.

I thought there might be a problem where you have a buffer that doesn't have a filename, but as far as I can tell the IDE doesn't let you do this.