### PR TITLE
Set working directory to the parent directory of formatted file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Ignore formatting requests for files without matching file extensions (pas, dpr, dpk, inc).
 
+### Changed
+
+* Working directory for `pasfmt` is now set to the parent directory of the file being formatted.
+  Previously, the parent directory of the active project file was used.
+
 ## [0.2.0] - 2025-03-18
 
 ### Added

--- a/Pasfmt.FormatCore.pas
+++ b/Pasfmt.FormatCore.pas
@@ -12,9 +12,8 @@ type
 
   TFormatter = record
     Executable: string;
-    WorkingDirectory: string;
     Timeout: Integer;
-    function Format(Input: UTF8String; Cursors: TArray<Integer>): TFormatResult;
+    function Format(Input: UTF8String; Cursors: TArray<Integer>; WorkingDirectory: string): TFormatResult;
   end;
 
 implementation
@@ -86,7 +85,7 @@ end;
 
 //______________________________________________________________________________________________________________________
 
-function TFormatter.Format(Input: UTF8String; Cursors: TArray<Integer>): TFormatResult;
+function TFormatter.Format(Input: UTF8String; Cursors: TArray<Integer>; WorkingDirectory: string): TFormatResult;
 var
   CommandLine: string;
   StdErr: UTF8String;

--- a/Pasfmt.FormatEditor.pas
+++ b/Pasfmt.FormatEditor.pas
@@ -139,7 +139,7 @@ var
 begin
   EditorContent := StreamToUTF8(SourceEditor.Content);
   try
-    FormatResult := Core.Format(EditorContent, Cursors.Serialize);
+    FormatResult := Core.Format(EditorContent, Cursors.Serialize, TPath.GetDirectoryName(Buffer.FileName));
   except
     on E: Exception do begin
       Log.Error('Format invocation failed: %s', [E.Message]);

--- a/Pasfmt.Main.pas
+++ b/Pasfmt.Main.pas
@@ -20,8 +20,7 @@ uses
   System.JSON,
   Pasfmt.Log,
   Pasfmt.OnSave,
-  System.Generics.Collections,
-  System.IOUtils;
+  System.Generics.Collections;
 
 type
   TPlugin = class(TObject)
@@ -151,18 +150,10 @@ end;
 //______________________________________________________________________________________________________________________
 
 procedure TPlugin.ConfigureFormatter(var Formatter: TEditBufferFormatter);
-var
-  Project: IOTAProject;
 begin
   Formatter.Core.Executable := PasfmtSettings.ExecutablePath;
   Formatter.Core.Timeout := PasfmtSettings.FormatTimeout;
   Formatter.MaxFileKiBWithUndoHistory := PasfmtSettings.MaxFileKiBWithUndoHistory;
-
-  Project := (BorlandIDEServices as IOTAModuleServices).GetActiveProject;
-  if Assigned(Project) then begin
-    // Ensures pasfmt is reading the config file if present
-    Formatter.Core.WorkingDirectory := TPath.GetDirectoryName(Project.FileName);
-  end;
 end;
 
 //______________________________________________________________________________________________________________________


### PR DESCRIPTION
This allows pasfmt to choose a config file closer to the file being
formatted.

Since an editor always has a filename (even before a new file is saved)
we can rely on extracting the directory this way and don't need to fall
back to the project directory.

Fixes #11.